### PR TITLE
Update PLAID link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Monitoring: an Up-to-Date Overview** [[pdf]](https://www.researchgate.net/profil
 - ECO [[link]](http://www.vs.inf.ethz.ch/res/show.html?what=eco-data)
 - HES [[link]](http://randd.defra.gov.uk/Default.aspx?Menu=Menu&Module=More&Location=None&ProjectID=17359&FromSearch=Y&Publisher=1&SearchText=EV0702&SortString=ProjectCode&SortOrder=Asc&Paging=10#Description)
 - Tracebase [[link]](https://github.com/areinhardt/tracebase)
-- PLAID [[link]](http://www.plaidplug.com/)
+- PLAID [[link]](https://www.nature.com/articles/s41597-020-0389-7)
 - ENERTALK [[link]](https://www.nature.com/articles/s41597-019-0212-5)
 
 ### Synthetic Datasets


### PR DESCRIPTION
Hi, we recently published a new version (and paper) about the PLAID dataset, so I updated the link to point to it: https://www.nature.com/articles/s41597-020-0389-7